### PR TITLE
suppress error messages

### DIFF
--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -28,7 +28,7 @@ if &hlsearch
 
     cnoremap <silent> <expr> <CR> <sid>Cool()
 
-    autocmd! CursorMoved * call <sid>Cooler()
+    autocmd! CursorMoved * silent! call <sid>Cooler()
 
     function! s:Cool()
         if getcmdtype() =~ '[/?]'


### PR DESCRIPTION
prevents highly annoying `E871: (NFA regexp) Can't have a multi follow a multi !`  messages from being shown every cursor move
