### PR TITLE
fix search(@/)

### DIFF
--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -31,15 +31,14 @@ endfunction
 
 function! s:StartHL()
     if v:hlsearch && mode() is 'n'
-        let patt = s:FixPat(@/)
-        silent! if !search('\%#\zs'.patt,'cnW')
+        silent! if !search('\%#\zs'.s:FixPat(@/),'cnW')
             call <SID>StopHL()
         elseif get(g:,'CoolTotalMatches') && exists('*reltimestr')
             exe "silent! norm! :let g:cool_char=nr2char(screenchar(screenrow(),1))\<cr>"
             if g:cool_char =~ '[/?]'
                 let [now, noOf, pos] = [reltime(), [0,0], getpos('.')]
                 for b in [0,1]
-                    while search(patt, 'Wb'[:b])
+                    while search(@/, 'Wb'[:b])
                         if reltimestr(reltime(now))[:-6] =~ '[1-9]'
                             " time >= 100ms
                             call setpos('.',pos)


### PR DESCRIPTION
Apparently, the smartcase exception works the same with `norm! n` and `search(@/)`
so the adding of `\c` is incorrect in the counting search