### PR TITLE
fix casing

### DIFF
--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -28,11 +28,11 @@ endif
 function! s:FixPat(pat)
     if &ignorecase
         let pos = getpos('.')
-        exe "silent! keepjumps norm! /" . histget('/',-1)."\<cr>" 
+        exe "silent! keepjumps norm! /" . histget('/',-1) . "\<cr>" 
         call setpos('.',pos)
-        if index([histget('/',-3), histget('/',-2)],histget('/',-1)) == 1
+        if histget('/',-1) ==# histget('/',-2)
             call histdel('search',-1)
-            return '\c'. a:pat
+            return '\c' . a:pat
         endif
     endif
     return a:pat

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -26,8 +26,7 @@ if exists('##OptionSet')
 endif
 
 function! s:FixPat(pat)
-    if &ignorecase && &smartcase && a:pat !~# '\%(^\|[^\\]\)\%(\\\\\)*\\C' &&
-                \ a:pat !~# '\%(^\|[^\\]\)\u'
+    if &ignorecase && &smartcase && a:pat !~# '\%(^\|[^\\]\)\%(\u\|\%(\\\\\)*\\C\)'
         return '\c'.a:pat
     endif
     return a:pat

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -30,7 +30,7 @@ function! s:FixPat(pat)
         let pos = getpos('.')
         exe "silent! keepjumps norm! /" . histget('/',-1)."\<cr>" 
         call setpos('.',pos)
-        if histget('/',-1) ==# histget('/',-2)
+        if index([histget('/',-2), histget('/',-3)],histget('/',-1)) !~ 1
             call histdel('search',-1)
             return '\c'. a:pat
         endif

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -26,7 +26,7 @@ if exists('##OptionSet')
 endif
 
 function! s:FixPat(pat)
-    if &ignorecase && &smartcase && a:pat !~# '\%(^\|[^\\]\)\%(\u\|\%(\\\\\)*\\C\)'
+    if &ignorecase && &smartcase && a:pat =~# '^\\<\k\+\\>$'
         return '\c'.a:pat
     endif
     return a:pat

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -26,7 +26,7 @@ if exists('##OptionSet')
 endif
 
 function! s:FixPat(pat)
-    return (&ignorecase && a:pat !~# '\%(^\|[^\\]\)\%(\\\\\)*\\C' ? '\c' : '').a:pat
+    return (&ignorecase && &smartcase && a:pat !~# '\%(^\|[^\\]\)\%(\\\\\)*\u' ? '\c' : '').a:pat
 endfunction
 
 function! s:StartHL()

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -26,13 +26,9 @@ if exists('##OptionSet')
 endif
 
 function! s:FixPat(pat)
-    if &ignorecase
-        let pos = winsaveview()
-        exe "noautocmd norm! /" . histget('/') . "\<cr>" 
-        call winrestview(pos)
-        if histget('/') ==# histget('/',-2)
-            return '\c' . a:pat
-        endif
+    if &ignorecase && &smartcase && a:pat !~# '\%(^\|[^\\]\)\%(\\\\\)*\\C' &&
+                \ a:pat !~# '\%(^\|[^\\]\)\u'
+        return '\c'.a:pat
     endif
     return a:pat
 endfunction

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -26,7 +26,7 @@ if exists('##OptionSet')
 endif
 
 function! s:FixPat(pat)
-    return (&ignorecase && &smartcase && a:pat !~# '\%(^\|[^\\]\)\%(\\\\\)*\u' ? '\c' : '').a:pat
+    return (&ignorecase && &smartcase && a:pat !~# '\%(^\|[^\\]\)\%(\\\\\)*\%(\u\|\\C\)' ? '\c' : '').a:pat
 endfunction
 
 function! s:StartHL()

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -28,7 +28,7 @@ endif
 function! s:FixPat(pat)
     if &ignorecase
         let pos = winsaveview()
-        exe "silent! noautocmd norm! /" . histget('/',-1) . "\<cr>" 
+        exe "silent! keeppat noautocmd norm! /" . histget('/',-1) . "\<cr>" 
         call winrestview(pos)
         if histget('/',-1) ==# histget('/',-2)
             return '\c' . a:pat

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -28,10 +28,9 @@ endif
 function! s:FixPat(pat)
     if &ignorecase
         let pos = winsaveview()
-        exe "silent! noautocmd keepjumps norm! /" . histget('/',-1) . "\<cr>" 
+        exe "silent! noautocmd norm! /" . histget('/',-1) . "\<cr>" 
         call winrestview(pos)
         if histget('/',-1) ==# histget('/',-2)
-            call histdel('search',-1)
             return '\c' . a:pat
         endif
     endif

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -28,7 +28,7 @@ endif
 function! s:FixPat(pat)
     if &ignorecase
         let pos = winsaveview()
-        exe "silent! keepjumps norm! /" . histget('/',-1) . "\<cr>" 
+        exe "silent! noautocmd keepjumps norm! /" . histget('/',-1) . "\<cr>" 
         call winrestview(pos)
         if histget('/',-1) ==# histget('/',-2)
             call histdel('search',-1)

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -30,7 +30,7 @@ function! s:FixPat(pat)
         let pos = getpos('.')
         exe "silent! keepjumps norm! /" . histget('/',-1)."\<cr>" 
         call setpos('.',pos)
-        if index([histget('/',-2), histget('/',-3)],histget('/',-1)) !~ 1
+        if index([histget('/',-3), histget('/',-2)],histget('/',-1)) == 1
             call histdel('search',-1)
             return '\c'. a:pat
         endif

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -27,9 +27,9 @@ endif
 
 function! s:FixPat(pat)
     if &ignorecase
-        let pos = getpos('.')
+        let pos = winsaveview()
         exe "silent! keepjumps norm! /" . histget('/',-1) . "\<cr>" 
-        call setpos('.',pos)
+        call winrestview(pos)
         if histget('/',-1) ==# histget('/',-2)
             call histdel('search',-1)
             return '\c' . a:pat

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -28,9 +28,9 @@ endif
 function! s:FixPat(pat)
     if &ignorecase
         let pos = winsaveview()
-        exe "silent! keeppat noautocmd norm! /" . histget('/',-1) . "\<cr>" 
+        exe "noautocmd norm! /" . histget('/') . "\<cr>" 
         call winrestview(pos)
-        if histget('/',-1) ==# histget('/',-2)
+        if histget('/') ==# histget('/',-2)
             return '\c' . a:pat
         endif
     endif

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -26,7 +26,16 @@ if exists('##OptionSet')
 endif
 
 function! s:FixPat(pat)
-    return (&ignorecase && &smartcase && a:pat !~# '\%(^\|[^\\]\)\%(\\\\\)*\%(\u\|\\C\)' ? '\c' : '').a:pat
+    if &ignorecase
+        let pos = getpos('.')
+        exe "silent! keepjumps norm! /" . histget('/',-1)."\<cr>" 
+        call setpos('.',pos)
+        if histget('/',-1) ==# histget('/',-2)
+            call histdel('search',-1)
+            return '\c'. a:pat
+        endif
+    endif
+    return a:pat
 endfunction
 
 function! s:StartHL()


### PR DESCRIPTION
@auwsmit the casing solution causes the normal search behaviour to change. For counting, and when the cursor is moved onto a match with an incorrect casing, etc.