### PR TITLE
Highlight match under the cursor with IncSearch

### DIFF
--- a/autoload/cool.vim
+++ b/autoload/cool.vim
@@ -1,0 +1,7 @@
+function! cool#HLMatch() abort
+    let [bufnum, lnum, col, off] = getpos('.')
+    let matchlen = strlen(matchstr(strpart(getline('.'),col-1),@/))
+    let target_pat = '\c\%#\%('.@/.'\)'
+    let ring = matchadd('IncSearch', target_pat, 101)
+    redraw
+endfunction

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -123,4 +123,11 @@ endfunction
 " play it cool
 call <SID>PlayItCool(0, &hlsearch)
 
+nnoremap <silent> n   n:call cool#HLMatch()<CR>
+nnoremap <silent> N   N:call cool#HLMatch()<CR>
+
+cnoremap <expr> <CR> getcmdtype()
+      \ == "/" \|\| getcmdtype()
+      \ == "?" ? "<CR>:call cool#HLMatch() <Bar> redraw<CR>" : "<CR>"
+
 let &cpo = s:save_cpo


### PR DESCRIPTION
Nothing much more to say; the current match is highlighted as IncSearch, making it more distinctive from all the other search results.

- Maybe this feature should be made optional, placed into an option…?
- Note that this is the first part of the plugin that involves mappings, making it much more fragile. Is this a risk worth taking, or maybe is there a way to write it without mappings?