### PR TITLE
Fix version check

### DIFF
--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -5,7 +5,7 @@
 " Location:	plugin/cool.vim
 " Website:	https://github.com/romainl/vim-cool
 
-if exists("g:loaded_cool") || v:version < 703 || &compatible
+if exists("g:loaded_cool") || v:version < 704 || &compatible
     finish
 endif
 let g:loaded_cool = 1


### PR DESCRIPTION
Hi.
I happened to run into Vim 7.3 recently, vim-cool doesn't play nice.

I've simply updated the version check to `v:version < 704` inline with the readme.
The errors are for `v:hlsearch` if you'd rather a feature check?