### PR TITLE
Fix some issues with neovim's terminal

### DIFF
--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -75,7 +75,7 @@ function! s:StartHL()
 endfunction
 
 function! s:StopHL()
-    if !v:hlsearch || mode() isnot 'n'
+    if !v:hlsearch || mode() isnot 'n' || &buftype == 'terminal'
         return
     else
         let g:cool_is_searching = 0


### PR DESCRIPTION
I know you don't want to officially support neovim, but this small change would fix multiple annoying issues I've encountered while using neovim's terminal in combination with vim cool. There is a chance that this would also solve other problems with plugins relying on neovim's terminal, including those of the issues #44 and #40 (although I can't reproduce them). It does fix a problem with [fzf-lua](https://github.com/ibhagwan/fzf-lua).

As far as I can tell, this change doesn't affect the behaviour in vim in any way.

### Neovim terminal issue

To reproduce, use the following init.vim (using vim-plug) with `nvim -u init.vim`:

```vim
call plug#begin()
Plug 'romainl/vim-cool'
call plug#end()

autocmd BufEnter * if &buftype == 'terminal' | :startinsert | endif
```

This is a fairly common configuration for the terminal in neovim as, contrary to vim's terminal, you can't switch between windows from the terminal's insert mode (you would usually use some mappings to change windows from the terminal that have to leave the terminal in normal mode).

Then:

- open two windows, one with a buffer containing some text you can search and one containing a terminal.
- search for some text then switch to the windows containing the terminal.

An escape code followed by `(StopHL)` will be inserted in the terminal window.


### Fzf-lua issue

To reproduce, use the following init.vim (using vim-plug) with `nvim -u init.vim`:

```vim
call plug#begin()
Plug 'romainl/vim-cool'
Plug 'ibhagwan/fzf-lua'
call plug#end()
```

Then, if you search for some text and try to launch `:FzfLua` (or another fzf-lua command), the command will fail silently.
