### PR TITLE
Highlight the current word under the cursor differently.

### DIFF
--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -30,7 +30,7 @@ function! s:StartHL()
         return
     endif
     " Highlight the current matching word differently
-    exec '2match IncSearch /\%#' . @/ . '/'
+    exec '2match IncSearch /\c\%#' . @/ . '/'
     let g:cool_is_searching = 1
     let [pos, rpos] = [winsaveview(), getpos('.')]
     silent! exe "keepjumps go".(line2byte('.')+col('.')-(v:searchforward ? 2 : 0))

--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -29,6 +29,8 @@ function! s:StartHL()
     if !v:hlsearch || mode() isnot 'n'
         return
     endif
+    " Highlight the current matching word differently
+    exec '2match IncSearch /\%#' . @/ . '/'
     let g:cool_is_searching = 1
     let [pos, rpos] = [winsaveview(), getpos('.')]
     silent! exe "keepjumps go".(line2byte('.')+col('.')-(v:searchforward ? 2 : 0))
@@ -78,6 +80,7 @@ function! s:StopHL()
     if !v:hlsearch || mode() isnot 'n' || &buftype == 'terminal'
         return
     else
+        2match none
         let g:cool_is_searching = 0
         silent call feedkeys("\<Plug>(StopHL)", 'm')
     endif


### PR DESCRIPTION
Highlight the current word under the cursor using `IncSearch` highlight group when search highlight is active.
Simple but really nice feature I always wished to have in Vim and found it to be so easy to implement with your plugin.
It could be wrapped in an if statement to make it optional. If you're interested to merge I could add that.