### PR TITLE
fix: highlighting stopped because of negative byte count

### DIFF
--- a/plugin/cool.vim
+++ b/plugin/cool.vim
@@ -31,7 +31,12 @@ function! s:StartHL()
     endif
     let g:cool_is_searching = 1
     let [pos, rpos] = [winsaveview(), getpos('.')]
-    silent! exe "keepjumps go".(line2byte('.')+col('.')-(v:searchforward ? 2 : 0))
+    let byte = line2byte('.')+col('.')-(v:searchforward ? 2 : 0)
+
+    if byte <= 0
+      return
+    endif
+    silent! exe "keepjumps go".byte
     try
         silent keepjumps norm! n
         if getpos('.') != rpos


### PR DESCRIPTION
When the cursor is at the beginning of the file the code silently fails because a negative byte is used for the jump and consequently highlighting is stopped.